### PR TITLE
Fixed LCD knob control

### DIFF
--- a/SD Card Structure/Bowden/sys/config.g
+++ b/SD Card Structure/Bowden/sys/config.g
@@ -55,3 +55,6 @@ T0                               ; Select first tool
 
 ; Manual Bed Leveling
 M558 P0
+
+;Configure LCD Display
+M918 P1 E4

--- a/SD Card Structure/Quad/sys/config.g
+++ b/SD Card Structure/Quad/sys/config.g
@@ -58,6 +58,9 @@ M106 P2 S1 I0 F500 H1 T45      ; Set fan 2 value, PWM signal inversion and frequ
 M98 P"0:/sys/StartupToolSetup"
 T0
 
+;Configure LCD Display
+M918 P1 E4
+
 ; Automatic saving after power loss is not enabled
 
 ; Custom settings are not configured


### PR DESCRIPTION
Resolved the issue where the control knob would only move 2 units on the display per click, making it difficult to navigate the display appropriately.