### PR TITLE
Update Heat_Hotend_Off

### DIFF
--- a/SD Card Structure/Quad/sys/Heat_Hotend_Off
+++ b/SD Card Structure/Quad/sys/Heat_Hotend_Off
@@ -1,2 +1,2 @@
-T-1
-
+G10 P0 R0; Sets the default tool to standby temp 0 C
+T-1; Inactivate tool


### PR DESCRIPTION
This addresses issue #15 

Added "G10 P0 R0" before the existing "T-1".

This causes the standby temp (for default tool, which is Tool 0 ) to be set to 0 C.